### PR TITLE
Improved init handling for arduino sensors

### DIFF
--- a/mechwolf/components/arduino.py
+++ b/mechwolf/components/arduino.py
@@ -25,8 +25,9 @@ class ArduinoSensor(Sensor):
             stopbits=1
             )
             
-        while self.ser.in_waiting:
-            self.ser.reset_input_buffer()
+        # Listen to sensor's self-introduction
+        # (gives it time for internal init)
+        intro = self.ser.readline()
 
         return self
 
@@ -37,7 +38,7 @@ class ArduinoSensor(Sensor):
     def read(self):
 
         # flush in buffer in case we have stale data
-        while self.ser.in_waiting:
+        if self.ser.in_waiting:
             self.ser.reset_input_buffer()
 
         # send the command
@@ -51,3 +52,4 @@ class ArduinoSensor(Sensor):
         except :
             # otherwise it is a float
             return float(data)
+


### PR DESCRIPTION
It turns out there is a lot of value in the sensor spitting out something once its internal initialization is complete, and us waiting for that. I run into a case where I was opening a serial port and immediately asking for a measurement before the sensor was ready. We now wait for a single line after opening the serial port. **All arduino based mechwolf sensors will spit out a single line greeting through serial once they are ready.** 

In retrospect, most commercial serial devices I interacted with also seem to do this. It is pretty reassuring.