### PR TITLE
Removed unnecessary sleep from gsioc driver

### DIFF
--- a/mechwolf/components/gsioc.py
+++ b/mechwolf/components/gsioc.py
@@ -3,9 +3,6 @@ try:
 except ImportError:
     pass
 
-from time import sleep
-
-
 class GsiocComponent:
     def __init__(self, serial_port=None, unit_id=0):
         self.ser = serial.Serial(
@@ -22,16 +19,12 @@ class GsiocComponent:
     def reset(self):
         self.immediate_command("$")
 
-    def disconnect(self):
-        # disconnect all slaves
-        self.ser.write([0xFF])
-        # give slaves time to disconnect
-        sleep(0.02)
-        self.ser.reset_input_buffer()
-
     def connect(self):
 
-        self.disconnect()
+        # disconnect all slaves
+        self.ser.write([0xFF])
+        self.ser.reset_input_buffer()
+
         # connect slave with this ID
         max_try = 3
         for i in range(max_try):


### PR DESCRIPTION
GSIOC spec requires we send disconnect signal, but since we are immediately confirming connection afterwards, we do not really need the explicit sleep to make sure device had time to disconnect. 
This whole process is really a relic of multiple devices daisy-chained on a rs422 line. We want to follow gsioc protocol as close as possible, hence the response checking, but it is safe to assume we do not have multiple devices on the line. 
This vastly improves latency since sleep was triggered multiple times for each update, since we send multiple GSIOC commands to update screen etc. 